### PR TITLE
Revert block timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The SparkSwap API is a set of endpoints used by market aggregators (e.g. coinmarketcap.com) to surface SparkSwap liquidity
 and volume information. All information is fetched from the underlying subgraphs.
 
-Subgraph: https://api.thegraph.com/subgraphs/name/aldrickb/sparkswapgraphv2
+Subgraph: https://api.thegraph.com/subgraphs/name/kojiadrianojr/sparkswap-v2-subgraph
 
 ## Documentation
 

--- a/utils/apollo/.graphqlconfig
+++ b/utils/apollo/.graphqlconfig
@@ -4,7 +4,7 @@
   "extensions": {
     "endpoints": {
       "SparkSwap v2": {
-        "url": "https://api.thegraph.com/subgraphs/name/aldrickb/sparkswapgraphv2",
+        "url": "https://api.thegraph.com/subgraphs/name/kojiadrianojr/sparkswap-v2-subgraph",
         "headers": {
           "user-agent": "JS GraphQL"
         },

--- a/utils/apollo/client.ts
+++ b/utils/apollo/client.ts
@@ -4,7 +4,7 @@ import fetch from "cross-fetch";
 export const client = new ApolloClient({
   link: new HttpLink({
     fetch,
-    uri: "https://api.thegraph.com/subgraphs/name/aldrickb/sparkswapgraphv2",
+    uri: "https://api.thegraph.com/subgraphs/name/kojiadrianojr/sparkswap-v2-subgraph",
   }),
   cache: new InMemoryCache(),
 });

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -30,8 +30,7 @@ const HOUR = 60 * MINUTE;
 const DAY = 24 * HOUR;
 
 export function get24HoursAgo(): number {
-  return 1620345600;
-  //return Math.floor((Date.now() - DAY) / 1000);
+  return Math.floor((Date.now() - DAY) / 1000);
 }
 
 const TOP_PAIR_LIMIT = 1000;
@@ -44,8 +43,7 @@ export interface MappedDetailedPair extends Pair {
 }
 
 export async function getTopPairs(): Promise<MappedDetailedPair[]> {
-  const epochSecond = 1620432000;
-  // const epochSecond = Math.floor(new Date().getTime() / 1000);
+  const epochSecond = Math.floor(new Date().getTime() / 1000);
   const firstBlock = await getBlockFromTimestamp(epochSecond - 86400);
 
   if (!firstBlock) {


### PR DESCRIPTION
Preview URL: https://sparkswap-info-api-kqcnoqisl-sparkpointio.vercel.app/api/

@kojiadrianojr, please verify if this is the correct URL from your updated subgraph with the fix for the whitelisting. Thanks.